### PR TITLE
⚡ Bolt: Optimize getStatus allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { TheWorkshopService } from './index';
+
+describe('TheWorkshopService', () => {
+  it('should return status', () => {
+    const service = new TheWorkshopService();
+    const status = service.getStatus();
+    expect(status).toEqual({ name: 'the-workshop', status: 'active' });
+  });
+
+  it('should return same frozen object on each call (optimized behavior)', () => {
+    const service = new TheWorkshopService();
+    const status1 = service.getStatus();
+    const status2 = service.getStatus();
+    // Optimized: returns cached object
+    expect(status1).toBe(status2);
+    expect(status1).toEqual(status2);
+    expect(Object.isFrozen(status1)).toBe(true);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@
 export class TheWorkshopService {
   private name = 'the-workshop';
   
+  // Cache the status object and freeze it to prevent mutations
+  private readonly status = Object.freeze({ name: this.name, status: 'active' });
+
   async start(): Promise<void> {
     console.log(`[${this.name}] Starting...`);
   }
@@ -14,7 +17,7 @@ export class TheWorkshopService {
   }
   
   getStatus() {
-    return { name: this.name, status: 'active' };
+    return this.status;
   }
 }
 


### PR DESCRIPTION
💡 What:
Optimized `getStatus` in `TheWorkshopService` to return a cached, frozen object instead of creating a new one on every call.

🎯 Why:
To reduce memory allocation and garbage collection overhead, especially if `getStatus` is called frequently (e.g., in a health check loop).

📊 Impact:
- Reduces object allocation for `getStatus` from O(1) per call to O(1) per instance.
- Ensures immutability of the returned status object.

🔬 Measurement:
- Verified with `src/index.test.ts` which checks that subsequent calls return the exact same object reference and that the object is frozen.

---
*PR created automatically by Jules for task [17629512537526098738](https://jules.google.com/task/17629512537526098738) started by @Trancendos*

## Summary by Sourcery

Cache and reuse a frozen status object in TheWorkshopService to reduce allocations and enforce immutability.

Enhancements:
- Optimize TheWorkshopService.getStatus to return a cached, immutable status object instead of constructing a new one per call.

Tests:
- Add tests to verify getStatus returns the same object reference across calls and that the returned status object is frozen.

Chores:
- Add a .gitignore file to exclude common project artifacts from version control.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized TheWorkshopService.getStatus to return a cached, frozen status object, reducing per-call allocations and GC churn. Added tests to verify same-object return and immutability, and updated .gitignore to ignore node_modules and dist.

<sup>Written for commit 5934b0d47b6be208707add0f6b19ebfa1d491946. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests for TheWorkshopService.getStatus() method.

* **Chores**
  * Updated .gitignore to exclude node_modules and build artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->