### PR TITLE
⚡ Bolt: Optimize getStatus allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2024-05-23 - Monorepo Workspace Dependency Workaround
+**Learning:** Isolated packages with `workspace:*` dependencies prevent `pnpm install` from working, blocking verification.
+**Action:** Temporarily remove `workspace:*` dependencies from `package.json` to enable dependency installation and testing, then restore them before submission.
+
+## 2024-05-23 - Lazy Initialization for Safer Optimization
+**Learning:** Class field initializers run in definition order, which can be brittle if dependencies are reordered. Lazy initialization in the accessor method is safer and avoids initialization order risks.
+**Action:** Prefer lazy initialization (`if (!this.cached) ...`) over immediate field initialization for caching dependent values.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { TheWorkshopService } from './index';
+
+describe('TheWorkshopService', () => {
+  it('getStatus returns correct structure', () => {
+    const service = new TheWorkshopService();
+    const status = service.getStatus();
+    expect(status).toEqual({ name: 'the-workshop', status: 'active' });
+  });
+
+  it('getStatus returns the same cached object reference (optimized)', () => {
+    const service = new TheWorkshopService();
+    const status1 = service.getStatus();
+    const status2 = service.getStatus();
+    // Optimization: returns same reference
+    expect(status1).toBe(status2);
+    expect(status1).toEqual(status2);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,14 @@ export class TheWorkshopService {
     console.log(`[${this.name}] Stopping...`);
   }
   
+  // Optimization: Cache status object lazily to avoid allocation on every call
+  private _status: { name: string; status: string } | undefined;
+
   getStatus() {
-    return { name: this.name, status: 'active' };
+    if (!this._status) {
+      this._status = Object.freeze({ name: this.name, status: 'active' });
+    }
+    return this._status;
   }
 }
 


### PR DESCRIPTION
### **User description**
⚡ Bolt: Optimize getStatus allocation

💡 What: Implemented lazy caching for the `getStatus` method in `TheWorkshopService`.
🎯 Why: The method previously allocated a new object on every call. For high-frequency calls, this creates unnecessary garbage collection pressure.
📊 Impact: Reduces allocations to exactly one per service instance (after first call). 
🔬 Measurement: Added a test case in `src/index.test.ts` verifying that subsequent calls return the exact same object reference (`expect(status1).toBe(status2)`).

Also added `.gitignore` and `.jules/bolt.md` for project hygiene and tracking.


---
*PR created automatically by Jules for task [6041806055232254037](https://jules.google.com/task/6041806055232254037) started by @Trancendos*


___

### **PR Type**
Enhancement


___

### **Description**
- Implement lazy caching for `getStatus` method to reduce allocations

- Use `Object.freeze` to ensure cached status immutability

- Add comprehensive test suite verifying caching behavior

- Document optimization learnings and workarounds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getStatus called"] --> B{"_status cached?"}
  B -->|No| C["Create frozen object"]
  C --> D["Store in _status"]
  D --> E["Return _status"]
  B -->|Yes| E
  E --> F["Same reference returned"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Implement lazy caching in getStatus method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<ul><li>Added private <code>_status</code> field for lazy caching<br> <li> Modified <code>getStatus</code> to check cache before creating object<br> <li> Applied <code>Object.freeze</code> to ensure immutability of cached status<br> <li> Reduces allocations from per-call to once per service instance</ul>


</details>


  </td>
  <td><a href="https://github.com/Trancendos/the-workshop/pull/8/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add tests for getStatus caching optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.test.ts

<ul><li>Added test verifying correct status structure returned<br> <li> Added test confirming same object reference on subsequent calls<br> <li> Uses <code>toBe</code> to verify optimization works as expected<br> <li> Validates both equality and reference identity</ul>


</details>


  </td>
  <td><a href="https://github.com/Trancendos/the-workshop/pull/8/files#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bolt.md</strong><dd><code>Document optimization learnings and workarounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/bolt.md

<ul><li>Documented monorepo workspace dependency workaround<br> <li> Documented lazy initialization pattern for safer optimization<br> <li> Captured learnings about initialization order risks<br> <li> Provided actionable guidance for future optimizations</ul>


</details>


  </td>
  <td><a href="https://github.com/Trancendos/the-workshop/pull/8/files#diff-b3d690d8d9366d3902c26b045ee8782b86e79c27d6af7770d085989e65198f63">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cached TheWorkshopService.getStatus so it returns the same frozen object after the first call, removing per-call allocations and reducing GC pressure.

- **Performance**
  - Lazy-initialize and cache the status object; use Object.freeze for immutability.
  - Reduce allocations to one per service instance; subsequent calls reuse the reference.
  - Added tests to verify structure and reference equality.

<sup>Written for commit 29f731ffec7b2d78539d5e1244eeee67897204a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for service status retrieval and caching behavior.

* **Documentation**
  * Added development notes on workspace dependency handling and lazy initialization patterns.

* **Chores**
  * Updated project ignore file to exclude build and dependency directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->