### PR TITLE
⚡ Bolt: Cache getStatus result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+coverage

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Workspace Dependency Isolation
+**Learning:** Isolated packages from a monorepo with `workspace:*` dependencies cannot install dependencies locally without the workspace root.
+**Action:** Temporarily remove `workspace:*` dependencies in `package.json` to allow `pnpm install` and local testing, then restore them before committing.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TheWorkshopService } from './index';
+
+describe('TheWorkshopService', () => {
+  it('should initialize with correct name', () => {
+    const service = new TheWorkshopService();
+    const status = service.getStatus();
+    expect(status).toEqual({ name: 'the-workshop', status: 'active' });
+  });
+
+  it('should return the same status object (cached)', () => {
+    const service = new TheWorkshopService();
+    const status1 = service.getStatus();
+    const status2 = service.getStatus();
+    expect(status1).toBe(status2); // Check referential equality
+  });
+
+  it('should be able to start and stop without error', async () => {
+    const service = new TheWorkshopService();
+    await expect(service.start()).resolves.toBeUndefined();
+    await expect(service.stop()).resolves.toBeUndefined();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 export class TheWorkshopService {
-  private name = 'the-workshop';
+  private readonly name = 'the-workshop';
   
   async start(): Promise<void> {
     console.log(`[${this.name}] Starting...`);
@@ -12,9 +12,15 @@ export class TheWorkshopService {
   async stop(): Promise<void> {
     console.log(`[${this.name}] Stopping...`);
   }
+
+  // Bolt: Cached status object to prevent redundant object creation
+  private cachedStatus: { name: string; status: string } | null = null;
   
   getStatus() {
-    return { name: this.name, status: 'active' };
+    if (!this.cachedStatus) {
+      this.cachedStatus = Object.freeze({ name: this.name, status: 'active' });
+    }
+    return this.cachedStatus;
   }
 }
 


### PR DESCRIPTION
### **User description**
Implemented lazy caching for `getStatus` in `TheWorkshopService` to prevent redundant object allocation. Marked `name` as `readonly` to ensure cache validity. Added tests to verify functionality and referential equality.

---
*PR created automatically by Jules for task [13562946055819487586](https://jules.google.com/task/13562946055819487586) started by @Trancendos*


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implement lazy caching for `getStatus` to prevent redundant object allocation

- Mark `name` property as `readonly` to ensure cache validity

- Add comprehensive test suite verifying functionality and referential equality

- Freeze cached status object to ensure immutability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getStatus called"] --> B{"cachedStatus exists?"}
  B -->|No| C["Create and freeze status object"]
  C --> D["Store in cachedStatus"]
  B -->|Yes| E["Return cached object"]
  D --> E
  E --> F["Return same instance"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Implement lazy caching for getStatus method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<ul><li>Mark <code>name</code> property as <code>readonly</code> to prevent accidental mutations<br> <li> Add <code>cachedStatus</code> private field to store the cached status object<br> <li> Implement lazy caching logic in <code>getStatus</code> method with <code>Object.freeze</code> <br>for immutability<br> <li> Return the same cached instance on subsequent calls</ul>


</details>


  </td>
  <td><a href="https://github.com/Trancendos/the-workshop/pull/9/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add comprehensive test suite for service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.test.ts

<ul><li>Add test verifying correct initialization with expected status object<br> <li> Add test confirming referential equality of cached status objects<br> <li> Add test verifying start and stop methods execute without errors</ul>


</details>


  </td>
  <td><a href="https://github.com/Trancendos/the-workshop/pull/9/files#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bolt.md</strong><dd><code>Document workspace dependency isolation learning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/bolt.md

<ul><li>Document learning about workspace dependency isolation in monorepos<br> <li> Record action taken to handle <code>workspace:*</code> dependencies during local <br>testing</ul>


</details>


  </td>
  <td><a href="https://github.com/Trancendos/the-workshop/pull/9/files#diff-b3d690d8d9366d3902c26b045ee8782b86e79c27d6af7770d085989e65198f63">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache getStatus in TheWorkshopService to return a single frozen status object and avoid creating new objects on each call. Marked name as readonly to keep the cache stable and added tests for referential equality and start/stop.

<sup>Written for commit 8797d227d02415aaf3c490ef60eb34f954888527. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

