### PR TITLE
⚡ Bolt: Optimize getStatus object allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-01 - Boundary Violation on Package Cleanup
+**Learning:** Removing unused dependencies from `package.json` constitutes a boundary violation of "Never modify package.json without instruction", even if it improves install performance.
+**Action:** Only optimize code within source files unless explicitly instructed to modify configuration or dependencies.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { TheWorkshopService } from './index';
+
+describe('TheWorkshopService', () => {
+  it('getStatus returns correct status', () => {
+    const service = new TheWorkshopService();
+    const status = service.getStatus();
+    expect(status).toEqual({ name: 'the-workshop', status: 'active' });
+  });
+
+  it('getStatus returns cached object reference (optimized)', () => {
+    const service = new TheWorkshopService();
+    const status1 = service.getStatus();
+    const status2 = service.getStatus();
+
+    // Performance optimization: verify we get the exact same object reference
+    expect(status1).toBe(status2);
+    expect(status1).toEqual(status2);
+  });
+
+  it('getStatus returns frozen object', () => {
+    const service = new TheWorkshopService();
+    const status = service.getStatus();
+    expect(Object.isFrozen(status)).toBe(true);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@
  */
 
 export class TheWorkshopService {
-  private name = 'the-workshop';
+  private readonly name = 'the-workshop';
+  // Optimization: Cache the status object to prevent object allocation on every call
+  private readonly cachedStatus = Object.freeze({ name: this.name, status: 'active' });
   
   async start(): Promise<void> {
     console.log(`[${this.name}] Starting...`);
@@ -14,7 +16,7 @@ export class TheWorkshopService {
   }
   
   getStatus() {
-    return { name: this.name, status: 'active' };
+    return this.cachedStatus;
   }
 }
 


### PR DESCRIPTION
### **User description**
💡 What: Memoized the `getStatus` return object and made it immutable.
🎯 Why: Prevents creating a new object on every call to `getStatus`, reducing garbage collection pressure for high-frequency polling.
📊 Impact: Reduces object allocation to zero for subsequent calls.
🔬 Measurement: Verified with `src/index.test.ts` checking for referential equality.

---
*PR created automatically by Jules for task [8293859739694078378](https://jules.google.com/task/8293859739694078378) started by @Trancendos*


___

### **PR Type**
Enhancement


___

### **Description**
- Memoize `getStatus` return object to eliminate allocation overhead

- Freeze cached status object to ensure immutability

- Add comprehensive tests verifying referential equality and immutability

- Document boundary violation learning in bolt.md


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getStatus called"] --> B["Return cached object"]
  B --> C["Same reference on each call"]
  D["Object.freeze applied"] --> E["Immutable status object"]
  C --> F["Zero allocation overhead"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Implement memoized and frozen status object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<ul><li>Changed <code>name</code> property to <code>readonly</code> for immutability<br> <li> Added <code>cachedStatus</code> private readonly field with frozen object <br>containing name and status<br> <li> Modified <code>getStatus()</code> method to return cached object instead of <br>creating new object<br> <li> Added optimization comment explaining the caching strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/Trancendos/the-workshop/pull/10/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add tests for memoization and immutability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.test.ts

<ul><li>Added test verifying <code>getStatus</code> returns correct status structure<br> <li> Added test confirming referential equality of cached object using <code>toBe</code> <br>assertion<br> <li> Added test validating that returned object is frozen using <br><code>Object.isFrozen</code><br> <li> Comprehensive test coverage for performance optimization</ul>


</details>


  </td>
  <td><a href="https://github.com/Trancendos/the-workshop/pull/10/files#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bolt.md</strong><dd><code>Document package.json modification boundary violation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/bolt.md

<ul><li>Documented learning about boundary violations regarding package.json <br>modifications<br> <li> Recorded that dependency cleanup constitutes unauthorized <br>configuration changes<br> <li> Established guideline to only optimize source code unless explicitly <br>instructed</ul>


</details>


  </td>
  <td><a href="https://github.com/Trancendos/the-workshop/pull/10/files#diff-b3d690d8d9366d3902c26b045ee8782b86e79c27d6af7770d085989e65198f63">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache and freeze the object returned by TheWorkshopService.getStatus to avoid per-call allocations. This reduces GC pressure during frequent polling and keeps the status immutable.

- **Refactors**
  - getStatus now returns a cached, frozen object; name is readonly.
  - Added tests for referential equality and immutability.

<sup>Written for commit 201f1ff54aa8b5424c5739fb4ecb2f871acb8933. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for service stability and performance verification.

* **Refactor**
  * Improved internal performance through caching and immutability enhancements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->