### PR TITLE
⚡ Bolt: Optimize getStatus with lazy caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+# Bolt Journal
+
+## 2024-05-22 - [Monorepo Isolation]
+**Learning:** This repo is an isolated workspace package. `workspace:*` dependencies fail to install.
+**Action:** Temporarily remove `workspace:*` deps in `package.json` to allow local installation and testing, then restore them before submitting.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { TheWorkshopService } from './index';
+
+describe('TheWorkshopService', () => {
+  it('should return default status', () => {
+    const service = new TheWorkshopService();
+    const status = service.getStatus();
+    expect(status).toEqual({ name: 'the-workshop', status: 'active' });
+  });
+
+  it('should start and stop without error', async () => {
+    const service = new TheWorkshopService();
+    await expect(service.start()).resolves.toBeUndefined();
+    await expect(service.stop()).resolves.toBeUndefined();
+  });
+
+  it('should return stable status object instance', () => {
+    const service = new TheWorkshopService();
+    const status1 = service.getStatus();
+    const status2 = service.getStatus();
+    expect(status1).toBe(status2);
+    expect(Object.isFrozen(status1)).toBe(true);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 
 export class TheWorkshopService {
   private name = 'the-workshop';
+  private _cachedStatus: Readonly<{ name: string; status: string }> | null = null;
   
   async start(): Promise<void> {
     console.log(`[${this.name}] Starting...`);
@@ -13,8 +14,15 @@ export class TheWorkshopService {
     console.log(`[${this.name}] Stopping...`);
   }
   
+  /**
+   * Returns the service status.
+   * Optimized to return a cached, frozen object to reduce memory allocation.
+   */
   getStatus() {
-    return { name: this.name, status: 'active' };
+    if (!this._cachedStatus) {
+      this._cachedStatus = Object.freeze({ name: this.name, status: 'active' });
+    }
+    return this._cachedStatus;
   }
 }
 


### PR DESCRIPTION
* 💡 **What:** Implemented lazy caching for `TheWorkshopService.getStatus()` using `Object.freeze`.
* 🎯 **Why:** Reduces memory allocation by returning a stable, immutable object instance instead of creating a new object on every call.
* 📊 **Impact:** Reduces object creation overhead for repeated status checks, improving garbage collection pressure in high-frequency usage scenarios.
* 🔬 **Measurement:** Verified with new unit tests in `src/index.test.ts`, confirming referential equality of returned status objects (`status1 === status2`).

---
*PR created automatically by Jules for task [3294961278248585175](https://jules.google.com/task/3294961278248585175) started by @Trancendos*

## Summary by Sourcery

Optimize TheWorkshopService status retrieval with cached, immutable responses and document local workspace constraints.

Enhancements:
- Cache and return a frozen status object in TheWorkshopService.getStatus() to reduce repeated allocations.

Documentation:
- Add a Bolt journal entry documenting monorepo workspace dependency installation constraints and the temporary workaround.

Tests:
- Introduce unit tests for TheWorkshopService.getStatus() to verify consistent, referentially equal status objects across calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized TheWorkshopService.getStatus to return a cached, frozen status object. This removes per-call allocations and reduces GC pressure in hot paths.

- **Performance**
  - Added lazy caching in getStatus to return the same immutable object across calls.
  - Added tests to verify referential stability and default status values.

<sup>Written for commit f3d3450fdd17c3a9a0776492927bbce8c3867e05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite verifying status retrieval, service methods, and object caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->